### PR TITLE
Update compat to support Parsers v2.0.0 release

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -18,7 +18,7 @@ CSV = "0.8.4"
 CategoricalArrays = "0.10.0"
 DataAPI = "1.6.0"
 DataFrames = "1.1.1"
-Parsers = "1.1.0"
+Parsers = "2"
 Tables = "1.4.2"
 julia = "1.6"
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -73,8 +73,8 @@ function constructparser(func, args, kwargs, returntype)
         opts = isnothing(kwargs) ? Parsers.Options() : Parsers.Options(kwargs...)
         function closure(val)
             len = val isa IO ? 0 : sizeof(val)  # Use default pos=1
-            x, code, vpos, vlen, tlen = Parsers.xparse(returntype, val isa AbstractString ? codeunits(val) : val, 1, len, opts)
-            Parsers.ok(code) ? x : missing
+            res = Parsers.xparse(returntype, val isa AbstractString ? codeunits(val) : val, 1, len, opts)
+            Parsers.ok(res.code) ? res.val : missing
         end
         return closure
     end


### PR DESCRIPTION
The `Parsers.xparse` contract changed from the v1.0 -> v2.0 release.
It now returns a `Parsers.Result{T}` object that includes the `code` and
`val` fields.